### PR TITLE
Remove debug definition from UFS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(hasParent)
   # with Ww3
   set(CMAKE_Fortran_FLAGS "")
   set(CMAKE_C_FLAGS "")
+  remove_definitions(-DDEBUG)
 endif()
 
 set(valid_caps "MULTI_ESMF" "NUOPC_MESH")


### PR DESCRIPTION
A variable named DEBUG conflicts and is replaced by the value `1`.